### PR TITLE
Update link for 'Neural Networks - A Systematic Introduction'

### DIFF
--- a/free-science-books.md
+++ b/free-science-books.md
@@ -8,7 +8,7 @@
 * [Computational Cognitive Neuroscience](https://github.com/CompCogNeuro/ed4) - Randall C. O’Reilly Yuko Munakata Michael J. Frank Thomas E. Hazy
 * [ePsych](https://epsych.msstate.edu) - Gary L. Bradshaw
 * [Instances of Cognition](https://www.crumplab.com/cognition/textbook) - Matthew J. Crump
-* [Neural Networks - A Systematic Introduction](http://page.mi.fu-berlin.de/rojas/neural/) - Raul Rojas
+* [Neural Networks - A Systematic Introduction](https://www.inf.fu-berlin.de/inst/ag-ki/rojas_home/documents/1996/NeuralNetworks/neuron.pdf) - Raul Rojas
 * [Neuronal Dynamics: From single neurons to networks and models of cognition](https://neuronaldynamics.epfl.ch) - Wulfram Gerstner, Werner M. Kistler, Richard Naud and Liam Paninski
 * [Neuroscience](https://www.bna.org.uk/static/uploads/resources/BNA_English.pdf) - British Neuroscience Association European Dana Alliance for the Brain (PDF)
 * [Neuroscience Online](https://nba.uth.tmc.edu/neuroscience/) - John H. Byrne


### PR DESCRIPTION
I fixed the broken link to the science book, "Neural Networks - A Systematic Introduction" by Raúl Rojas.

## What does this PR do?
Improve Repo

## For resources
### Description 

This is a free computer science textbook that covers a comprehensive and systematic introduction to the theory of neural networks. 

### Why is this valuable (or not)

Users may now visit the updated PDF link.

### How do we know it's really free?

I can download it directly as a PDF file with no issues.

### For book lists, is it a book?

Yes, this is a book.

### Checklist:
- [X] Not a duplicate
- [X] Included author(s) if appropriate
- [X] Lists are in alphabetical order
- [X] Needed indications added (PDF, access notes, under construction)
