### PR TITLE
Fixed Broken Neuroscience link to new PDF source

### DIFF
--- a/free-science-books.md
+++ b/free-science-books.md
@@ -10,7 +10,7 @@
 * [Instances of Cognition](https://www.crumplab.com/cognition/textbook) - Matthew J. Crump (HTML, PDF)
 * [Neural Networks - A Systematic Introduction](https://www.inf.fu-berlin.de/inst/ag-ki/rojas_home/documents/1996/NeuralNetworks/neuron.pdf) - Raul Rojas (PDF)
 * [Neuronal Dynamics: From single neurons to networks and models of cognition](https://neuronaldynamics.epfl.ch) - Wulfram Gerstner, Werner M. Kistler, Richard Naud, Liam Paninski (HTML)
-* [Neuroscience](https://www.bna.org.uk/static/uploads/resources/BNA_English.pdf) - British Neuroscience Association European Dana Alliance for the Brain (PDF)
+* [Neuroscience](https://dm16174grt2cj.cloudfront.net/Downloads_Research/NeuroScience-The-Science-Of-Brain.pdf) - British Neuroscience Association European Dana Alliance for the Brain (PDF)
 * [Neuroscience Online](https://nba.uth.tmc.edu/neuroscience/) - John H. Byrne (HTML)
 * [Principles of Psychology and Neuroscience](https://principlesofpsych.org) - Randall C. O’Reilly (PDF, HTML, EPUB, KPF)
 * [Probabilistic Models of Cognition](https://probmods.org) - Noah D. Goodman et al. (HTML)


### PR DESCRIPTION
I have updated the broken link in this Neuroscience textbook. The old one is no longer accessible.

## What does this PR do?
Improve Repo

## For resources
### Description 
This is a Neuroscience (Science of the Brain) Introduction textbook for young students.

### Why is this valuable (or not)
Users may now visit the updated PDF link.

### How do we know it's really free?
I can download it directly as a PDF file with no issues.

### For book lists, is it a book?
Yes, this is a book. 

### Checklist:
- [X] Not a duplicate
- [X] Included author(s) if appropriate
- [X] Lists are in alphabetical order
- [X] Needed indications added (PDF, access notes, under construction)
