### PR TITLE
Updated broken links in Physics section and added new resource

### DIFF
--- a/free-science-books.md
+++ b/free-science-books.md
@@ -97,42 +97,43 @@
 
 ## (QC) Physics
 
-* [A Text Book for High School Students Studying Physics](http://ftp.igh.cnrs.fr/pub/nongnu//fhsst/Physics_Grade_10-12.pdf) - FHSST Authors (PDF)
+* [A Text Book for High School Students Studying Physics](https://ftp.up.pt/pub/nongnu/fhsst/Physics_Grade_10-12.pdf) - FHSST Authors (PDF)
 * [An introduction to Physics](http://eacpe.org/content/uploads/2014/01/PHYSICS-101.pdf) - Pervez Hoodbhoy (PDF)
-* [Atomic and Molecular Physics - Lecture Notes](http://www.yorku.ca/tomk/PHYS4011-W13.pdf) - Tom Kirchner (PDF)
+* [Atomic and Molecular Physics - Lecture Notes](https://www.yorku.ca/professor/tomk/wp-content/uploads/sites/755/2023/02/PHYS4011.pdf) - Tom Kirchner (PDF)
 * [Chaos: Classical and Quantum](http://chaosbook.org) - Predrag Cvitanović, Roberto Artuso, Ronnie Mainieri et al.
 * [Classical Dynamics](http://www.damtp.cam.ac.uk/user/tong/dynamics/clas.pdf) - David Tong (PDF)
 * [Classical Mechanics](http://www.physics.rutgers.edu/ugrad/494/bookr03D.pdf) - Joel A. Shapiro (PDF)
+* [College Physics, 2nd Ed.](https://openstax.org/details/books/college-physics-2e) - Paul Peter Urone, Roger Hinrichs (HTML, PDF)
 * [Conceptual Physics](https://www.lightandmatter.com/cp) - Benjamin Crowell (PDF)
 * [Dynamics and Relativity](http://www.damtp.cam.ac.uk/user/tong/relativity/dynrel.pdf) - David Tong (PDF)
 * [Fields and Circuits](https://www.lightandmatter.com/fac) - Benjamin Crowell (PDF)
 * [Fundamental Physics for Level 0 - Teaching Guide](https://web.archive.org/web/20170701234819/https://oup.com.pk/media/teaching-guides/Fundamental%20Biology%20Physics%20Chemistry/Fundamental%20Physics%20for%20O%20Level%20Teaching%20Guide.pdf) - Ian Collins (PDF)
 * [Fusion Physics](https://www-pub.iaea.org/MTCD/Publications/PDF/Pub1562_web.pdf) - (PDF)
 * [General Relativity](https://www.lightandmatter.com/genrel) - Benjamin Crowell (PDF)
-* [GRE Physics Test Practice Book](https://www.ets.org/s/gre/pdf/practice_book_physics.pdf) - (PDF)
+* [GRE Physics Test Practice Book](https://www.ets.org/content/dam/ets-india/pdfs/gre/practice-book-physics.pdf) - (PDF)
 * [Introduction to General Relativity](http://www.staff.science.uu.nl/~hooft101/lectures/genrel_2013.pdf) - Gerard ’t Hooft (PDF)
 * [Introductory Physics I - Elementary Mechanics](https://webhome.phy.duke.edu/~rgb/Class/intro_physics_1/intro_physics_1.pdf) - R.G. Brown (PDF)
 * [Lecture Notes in Quantum Mechanics](https://physics.bgu.ac.il/~dcohen/ARCHIVE/qmc.pdf) - Doron Cohen (PDF)
 * [Lecture Notes on General Relativity](https://home.uni-leipzig.de/~tet/wp-content/uploads/2014/04/GR2015_0903.pdf) - Hollands and Sanders (PDF)
-* [Lecture Notes on Thermodynamics](http://www.crectirupati.com/sites/default/files/lecture_notes/TD-lecture%20notes.pdf) - Munirathnam (PDF)
+* [Lecture Notes on Thermodynamics](https://www.scribd.com/document/500422470/TD-lecture-notes) - Munirathnam (PDF) *(account required)*
 * [Light and Matter](https://www.lightandmatter.com/lm) - Benjamin Crowell (PDF)
 * [Mathematical Methods in Physics - Course Notes](https://www.pa.ucla.edu/faculty-websites/dhoker-lecture-notes/graduate-courses/231A-lecture-notes-15.pdf) - Eric D’Hoker (PDF)
 * [Modern Physics](https://www.lightandmatter.com/mod) - Benjamin Crowell (PDF)
 * [Motion Mountain Physics](http://www.motionmountain.net) - Christoph Schiller
-* [Physics Before and After Einstein](http://www.dmi.unipg.it/mamone/pubb/PBAE.pdf) - Marco Mamone Capria (PDF)
-* [Physics Test Practice Book](https://www.physics.ohio-state.edu/undergrad/greStuff/exam_GR9677.pdf) - (PDF)
+* [Physics Before and After Einstein](https://ebooks.iospress.nl/book/physics-before-and-after-einstein) - Marco Mamone Capria (PDF)
+* [Physics Test Practice Book](https://www.ets.org/pdfs/gre/practice-book-physics.pdf) - (PDF)
 * [Problems in Introductory Physics](http://www.lightandmatter.com/problems/problems.pdf) - B. Crowell and B. Shotwell (PDF)
-* [Radiation and particle detectors (2011)](https://www.asc.ohio-state.edu/honscheid.1/s12-780/references/turku_lecturenotes.pdf) - Edwin Kukk (PDF)
-* [Radiaton Physics for Personnel and Environmental Protection (2007)](https://www-esh.fnal.gov/TM1834_PDF_Files/TM_1834_Revision_9B.pdf) - J. Donald Cossairt (PDF)
+* [Radiation and Particle Detectors (2011)](https://www.asc.ohio-state.edu/honscheid.1/s12-780/references/turku_lecturenotes.pdf) - Edwin Kukk (PDF)
+* [Radiation Physics for Personnel and Environmental Protection (2007)](https://www-esh.fnal.gov/TM1834_PDF_Files/TM_1834_Revision_9B.pdf) - J. Donald Cossairt (PDF)
 * [Relativity for Poets](https://www.lightandmatter.com/poets) - Benjamin Crowell (PDF)
 * [Special Relativity](https://www.lightandmatter.com/sr) - Benjamin Crowell (PDF)
 * [Statistical Physics](http://www.damtp.cam.ac.uk/user/tong/statphys/sp.pdf) - David Tong (PDF)
-* [Structure and Interpretation of Classical Mechancics](https://mitpress.mit.edu/sites/default/files/titles/content/sicm_edition_2/book.html) - Gerald Jay Sussman and Jack Wisdom
+* [Structure and Interpretation of Classical Mechanics, 2nd Ed.](https://mitp-content-server.mit.edu/books/content/sectbyfn/books_pres_0/9579/sicm_edition_2.zip/book.html) - Gerald Jay Sussman and Jack Wisdom
 * [The Feynman Lectures on Physics](http://feynmanlectures.caltech.edu) - Richard P. Feynmann
 * [The Physics Hypertextbook](https://physics.info) - Glenn Elert
-* [University Physics, Volume 1](https://openstax.org/details/books/university-physics-volume-1) - William Moebs, Samuel J. Ling, Jeff Sanny et al. (PDF)
-* [University Physics, Volume 2](https://openstax.org/details/books/university-physics-volume-2) - William Moebs, Samuel J. Ling, Jeff Sanny et al. (PDF)
-* [University Physics, Volume 3](https://openstax.org/details/books/university-physics-volume-3) - William Moebs, Samuel J. Ling, Jeff Sanny et al. (PDF)
+* [University Physics, Volume 1](https://openstax.org/details/books/university-physics-volume-1) - William Moebs, Samuel J. Ling, Jeff Sanny et al. (HTML, PDF)
+* [University Physics, Volume 2](https://openstax.org/details/books/university-physics-volume-2) - William Moebs, Samuel J. Ling, Jeff Sanny et al. (HTML, PDF)
+* [University Physics, Volume 3](https://openstax.org/details/books/university-physics-volume-3) - William Moebs, Samuel J. Ling, Jeff Sanny et al. (HTML, PDF)
 
 
 ## (QD) Chemistry


### PR DESCRIPTION
I updated all of the broken links in the Physics section of this science book list.

## What does this PR do?
Add Resource, Improve Repo

## For resources
### Description 
There were several broken links in the "Physics" section, so I updated all of the current links. I also added a free College Physics, 2nd Edition textbook from OpenStax. 

### Why is this valuable (or not)
Users are now able to visit this list with the correct links and also benefit from this new free resource.

### How do we know it's really free?
Except for one that requires a free trial account (which the user can download for free), all of the links to these free resources are accessible online. 

### For book lists, is it a book?
Yes, these are all books.

### Checklist:
- [X] Not a duplicate
- [X] Included author(s) if appropriate
- [X] Lists are in alphabetical order
- [X] Needed indications added (PDF, access notes, under construction)
